### PR TITLE
最終更新日時が1年以上前のものはリストアップしてSlackへ通知するよう設定

### DIFF
--- a/.github/workflows/get_outdated_wiki_files.yml
+++ b/.github/workflows/get_outdated_wiki_files.yml
@@ -2,8 +2,7 @@ name: Get outdated wiki pages
 
 on:
   schedule:
-    - cron: '51 4 * * *' # This runs every day at 13:51 JST
-    # - cron: '0 0 * * 4' # This runs every Thursday at 00:00 UTC, which is Friday at 09:00 JST
+    - cron: '0 0 * * 4' # This runs every Thursday at 00:00 UTC, which is Friday at 09:00 JST
 
 jobs:
   check-wiki:
@@ -21,7 +20,7 @@ jobs:
         echo "| Pages | Last update |" >> MaintenanceList.md
         echo "| --- | --- |" >> MaintenanceList.md
 
-        OFFSET_DAYS=10
+        OFFSET_DAYS=365
         THRESHOLD_DATE=$(TZ="Asia/Tokyo" date -d "$OFFSET_DAYS days ago" +'%Y-%m-%d %H:%M:%S')
         echo "THRESHOLD_DATE :" $THRESHOLD_DATE
         CHANGES_MADE=false


### PR DESCRIPTION
## 変更の概要
- 毎週金曜日に最終更新日時が1年以上前のwikiがあるかチェックして、wikiのMaintenanceListへ古いwikiページの一覧を表示します。合わせて、Slackへ通知するよう設定しました。

## なぜこの変更が必要か？
- この変更を行う背景や理由を記述してください。

## やったこと
- [ ] 何をしたのかをチェックリスト形式で記述してください。

## 関連するIssue
- このPRに関連するIssueのリンクをこちらに貼ってください。

## 参考文献
- 関連するドキュメントや外部リンクがあれば、こちらに追加してください。

---

## チェックリスト
- [x] 該当するラベルを設定
- [ ] [IssueのURL] に記載の機能要件・非機能要件を満足していることを確認
