### PR TITLE
nginxのログを出力します

### DIFF
--- a/apps/backend/config/puma.rb
+++ b/apps/backend/config/puma.rb
@@ -43,7 +43,8 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 plugin :tmp_restart
 
 app_root = File.expand_path("..", __dir__)
-# nginx.confのserverと一致させる。
-bind "unix://#{app_root}/tmp/sockets/puma.sock"
+# nginx.confのserverと一致させる設定
+# bind "unix://#{app_root}/tmp/sockets/puma.sock"
+bind "tcp://0.0.0.0:3000"
 
 stdout_redirect "#{app_root}/log/puma.stdout.log", "#{app_root}/log/puma.stderr.log", true

--- a/apps/backend/containers/nginx/Dockerfile
+++ b/apps/backend/containers/nginx/Dockerfile
@@ -4,10 +4,17 @@ FROM nginx:1.18.0
 RUN rm -f /etc/nginx/conf.d/*
 
 # Nginxの設定ファイルをコンテナにコピー
-ADD ./nginx.conf /etc/nginx/conf.d/caian_app.conf
+COPY ./nginx.conf /etc/nginx/conf.d/caian_app.conf
 
-# for health check
-RUN apt-get update && apt-get install -y curl
+# ヘルスチェックとクリーンアップを追加
+RUN apt-get update && \
+    apt-get install -y curl && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# ヘルスチェックの設定
+HEALTHCHECK --interval=30s --timeout=3s \
+    CMD curl --silent --fail http://localhost/ || exit 1
 
 # ビルド完了後にNginxを起動
-CMD /usr/sbin/nginx -g 'daemon off;' -c /etc/nginx/nginx.conf
+CMD ["/usr/sbin/nginx", "-g", "daemon off;", "-c", "/etc/nginx/nginx.conf"]

--- a/apps/backend/containers/nginx/Dockerfile
+++ b/apps/backend/containers/nginx/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # ヘルスチェックの設定
-HEALTHCHECK --interval=30s --timeout=3s \
-    CMD curl --silent --fail http://localhost/ || exit 1
+# HEALTHCHECK --interval=30s --timeout=3s \
+#     CMD curl --silent --fail http://localhost/ || exit 1
 
 # ビルド完了後にNginxを起動
 CMD ["/usr/sbin/nginx", "-g", "daemon off;", "-c", "/etc/nginx/nginx.conf"]

--- a/apps/backend/containers/nginx/nginx.conf
+++ b/apps/backend/containers/nginx/nginx.conf
@@ -1,8 +1,8 @@
 # プロキシ先の指定
 # Nginxが受け取ったリクエストをバックエンドのpumaに送信
-upstream caian_app {
+upstream app {
   # ソケット通信したいのでpuma.sockを指定
-  server unix:///caian_app/tmp/sockets/puma.sock;
+  server app:3000;
 }
 
 # サーバーの設定
@@ -17,7 +17,7 @@ server {
   access_log /var/log/nginx/access.log;
   error_log  /var/log/nginx/error.log;
 
-   # ドキュメントルートの指定 / 接続が来た際のrootディレクトリ
+  # ドキュメントルートの指定 / 接続が来た際のrootディレクトリ
 
   client_max_body_size 100m;
   error_page 404             /404.html;
@@ -36,6 +36,6 @@ server {
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $http_host;
-    proxy_pass http://caian_app;
+    proxy_pass http://app;
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,9 +26,9 @@ services:
         source: ./apps/backend
         target: /caian-app
         consistency: delegated
-      - ./apps/backend/.docker/nginx.conf.template:/etc/nginx/templates/nginx.conf.template
+      - ./apps/backend/containers/nginx/nginx.conf:/etc/nginx/templates/nginx.conf
       - tmp-data:/caian-app/tmp
-      - tmp-data:/caian-app/public
+      - public-data:/caian-app/public
     tty: true
     stdin_open: true
     depends_on:
@@ -58,14 +58,20 @@ services:
     ports:
       - 80:80
     volumes:
-      - ./apps/backend/.docker/nginx.conf.template:/etc/nginx/templates/nginx.conf.template
+      - ./apps/backend/containers/nginx/nginx.conf:/etc/nginx/templates/nginx.conf
+      - nginx-logs:/var/log/nginx
       - tmp-data:/caian-app/tmp
+      - public-data:/caian-app/public
     depends_on:
       - app
 volumes:
   mysql-data:
     driver: local
   tmp-data:
+    driver: local
+  public-data:
+    driver: local
+  nginx-logs:
     driver: local
 networks:
   default:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       context: ./apps/backend
       dockerfile: Dockerfile
     ports:
-      - 3000:3000
+      - "3000:3000"
     volumes:
       - type: bind
         source: ./apps/backend
@@ -56,7 +56,7 @@ services:
     build:
       context: ./apps/backend/containers/nginx
     ports:
-      - 80:80
+      - "80:80"
     volumes:
       - ./apps/backend/containers/nginx/nginx.conf:/etc/nginx/templates/nginx.conf
       - nginx-logs:/var/log/nginx


### PR DESCRIPTION
## 変更の概要
nginxの`access.log`と`error.log`をコンテナのログに出力します。

appとnginxコンテナとの疎通を確認する方法として下記のコマンドでヘルスチェックできます。
```
$ docker exec -it caian-nginx-1 curl --silent --fail http://localhost/ || exit 1
```

`http://localhost/`でアクセスしてアクセスログが出力されることを確認した。

## なぜこの変更が必要か？
- この変更を行う背景や理由を記述してください。

## やったこと
- [ ] 何をしたのかをチェックリスト形式で記述してください。

## 関連するIssue
- このPRに関連するIssueのリンクをこちらに貼ってください。

## 参考文献
- 関連するドキュメントや外部リンクがあれば、こちらに追加してください。

---

## チェックリスト
- [ ] 該当するラベルを設定
- [ ] [IssueのURL] に記載の機能要件・非機能要件を満足していることを確認
