### PR TITLE
Gemfileのバージョン指定を極力しない方針で実装します。

### DIFF
--- a/apps/backend/Gemfile
+++ b/apps/backend/Gemfile
@@ -4,7 +4,7 @@ ruby "3.0.3"
 
 # Core
 gem 'rails', '~> 6.1.4', '>= 6.1.4.6'
-gem 'puma', '~> 5.6'
+gem 'puma'
 gem 'mysql2'
 gem 'bcrypt'
 

--- a/apps/backend/Gemfile
+++ b/apps/backend/Gemfile
@@ -27,7 +27,7 @@ gem 'jbuilder'
 gem 'rack-cors'
 
 # Optimizations
-gem 'bootsnap', '>= 1.4.4', require: false
+gem 'bootsnap', require: false
 
 # For Windows users
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/apps/backend/Gemfile
+++ b/apps/backend/Gemfile
@@ -40,7 +40,7 @@ group :development do
   gem 'rubocop'
   gem 'rubocop-rails'
   gem 'bullet'
-  gem 'rack-mini-profiler', '~> 2.0', require: false
+  gem 'rack-mini-profiler', require: false
 end
 
 group :development, :test do

--- a/apps/backend/Gemfile
+++ b/apps/backend/Gemfile
@@ -44,8 +44,8 @@ group :development do
 end
 
 group :development, :test do
-  gem 'rspec-rails', '~> 5.0.0'
-  gem 'factory_bot_rails', '5.2.0'
+  gem 'rspec-rails'
+  gem 'factory_bot_rails'
   gem 'faker'
 end
 

--- a/apps/backend/Gemfile
+++ b/apps/backend/Gemfile
@@ -50,7 +50,7 @@ group :development, :test do
 end
 
 group :test do
-  gem 'capybara', '>= 3.26'
+  gem 'capybara'
   gem 'selenium-webdriver'
   gem 'rails-controller-testing'
   gem 'minitest'

--- a/apps/backend/Gemfile
+++ b/apps/backend/Gemfile
@@ -26,6 +26,12 @@ gem 'dotenv-rails'
 gem 'jbuilder'
 gem 'rack-cors'
 
+# Optimizations
+gem 'bootsnap', '>= 1.4.4', require: false
+
+# For Windows users
+gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
 group :development do
   gem 'pry-rails'
   gem 'web-console'
@@ -52,9 +58,3 @@ group :test do
   gem 'guard'
   gem 'guard-minitest'
 end
-
-# Optimizations
-gem 'bootsnap', '>= 1.4.4', require: false
-
-# For Windows users
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/apps/backend/Gemfile
+++ b/apps/backend/Gemfile
@@ -26,7 +26,6 @@ gem 'dotenv-rails'
 gem 'jbuilder'
 gem 'rack-cors'
 
-# Development and debugging
 group :development do
   gem 'pry-rails'
   gem 'web-console'
@@ -38,7 +37,6 @@ group :development do
   gem 'rack-mini-profiler', '~> 2.0', require: false
 end
 
-# Testing
 group :development, :test do
   gem 'rspec-rails', '~> 5.0.0'
   gem 'factory_bot_rails', '5.2.0'

--- a/apps/backend/Gemfile.lock
+++ b/apps/backend/Gemfile.lock
@@ -314,7 +314,7 @@ PLATFORMS
 
 DEPENDENCIES
   bcrypt
-  bootsnap (>= 1.4.4)
+  bootsnap
   bullet
   capybara (>= 3.26)
   dotenv-rails

--- a/apps/backend/Gemfile.lock
+++ b/apps/backend/Gemfile.lock
@@ -318,7 +318,7 @@ DEPENDENCIES
   bullet
   capybara (>= 3.26)
   dotenv-rails
-  factory_bot_rails (= 5.2.0)
+  factory_bot_rails
   faker
   guard
   guard-minitest
@@ -337,7 +337,7 @@ DEPENDENCIES
   rack-mini-profiler
   rails (~> 6.1.4, >= 6.1.4.6)
   rails-controller-testing
-  rspec-rails (~> 5.0.0)
+  rspec-rails
   rubocop
   rubocop-rails
   sass-rails (>= 6)

--- a/apps/backend/Gemfile.lock
+++ b/apps/backend/Gemfile.lock
@@ -332,7 +332,7 @@ DEPENDENCIES
   mysql2
   pre-commit
   pry-rails
-  puma (~> 5.6)
+  puma
   rack-cors
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.4, >= 6.1.4.6)

--- a/apps/backend/Gemfile.lock
+++ b/apps/backend/Gemfile.lock
@@ -316,7 +316,7 @@ DEPENDENCIES
   bcrypt
   bootsnap
   bullet
-  capybara (>= 3.26)
+  capybara
   dotenv-rails
   factory_bot_rails
   faker

--- a/apps/backend/Gemfile.lock
+++ b/apps/backend/Gemfile.lock
@@ -334,7 +334,7 @@ DEPENDENCIES
   pry-rails
   puma
   rack-cors
-  rack-mini-profiler (~> 2.0)
+  rack-mini-profiler
   rails (~> 6.1.4, >= 6.1.4.6)
   rails-controller-testing
   rspec-rails (~> 5.0.0)


### PR DESCRIPTION
## 変更の概要


## なぜこの変更が必要か？
`Dependabot alerts`の通知でよく古いバージョンによる脆弱性が見つかるので、極力最新を保つようにバージョン指定の不要なものは一旦外してセキリュティリスクを下げたいと思います。
https://github.com/aki366/caian-app/security/dependabot

## やったこと
- [x] Gemfileの更新

## 関連するIssue
- なし

## 参考文献
- [Rails初心者に送る「Bundlerチョットワカルマニュアル」](https://qiita.com/jnchito/items/823323e276d1a90ac4a1)

---

## チェックリスト
- [x] 該当するラベルを設定
- 受け入れ要件
  - [ ] あり
    - [ ] [IssueのURL] に記載の機能要件・非機能要件を満足していることを確認
  - [x] なし