### PR TITLE
RspecのCIで差分に.rbファイルがなければ実行しない処理を追加

### DIFF
--- a/.github/workflows/rspec-results.yml
+++ b/.github/workflows/rspec-results.yml
@@ -28,8 +28,11 @@ jobs:
         options: --health-cmd "mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 10
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: ruby/setup-ruby@v1
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.0.3
           bundler-cache: true


### PR DESCRIPTION
## 目的・背景
.rbファイルがないのにbundle installを実行していたりと時間がもったいないので、`.rb`ファイルがなければ、スキップする処理を追加します。

## 受け入れ要件
- [x] なし
- [ ] あり
  - [ ] [URL](URL) を参照ください。

## 実装の概要
- nameの漏れていた箇所を追加しました
- .rbファイルがない場合は処理をスキップします

## レビューで特に見て欲しいところ、不安に思っているところ
- レビューで特に見て欲しいところや、不安に思っているところがあれば記述してください。

## 関連資料
- このPRに関連する資料のリンクをこちらに貼ってください。

## 参考文献
- 関連するドキュメントや外部リンクがあれば、こちらに追加してください。

---

## チェックリスト
- [x] 該当するラベルを設定