### PR TITLE
VScodeのデバッグtasksを定義

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,7 +5,8 @@
     {
       "label": "Run RSpec current file with line",
       "type": "shell",
-      "command": "docker compose -f docker-compose.yml exec -it app /bin/bash -c \"bundle exec rspec -fd -ff ${relative}:${input:LineNumber}\"",
+      // "command": "echo ./$(echo ${relativeFile} | sed 's|apps/backend/||')",
+      "command": "docker compose -f docker-compose.yml exec -it app /bin/bash -c \"bundle exec rspec -fd -ff ./$(echo ${relativeFile} | sed 's|apps/backend/||')\"",
       "group": "test",
       "problemMatcher":[
         {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,28 @@
+// tasks.json
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Run RSpec current file with line",
+      "type": "shell",
+      "command": "cd apps/backend && bundle exec rspec -fd -ff ${relative}:${input:LineNumber}",
+      "group": "test",
+      "problemMatcher":[
+        {
+          "owner": "ruby",
+          "fileLocation": ["relative", "${workspaceFolder}"],
+          "pattern": {
+            "regexp": "^rspec\\s+(.*):(\\d+)\\s+#\\s+(.*)$",
+            "file": 1, "line": 2, "message": 3
+          }
+        }
+      ]
+    } ],
+    "inputs": [
+      {
+        "id": "LineNumber",
+        "type": "promptString",
+        "description": "Enter the line number to run RSpec on:"
+      }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,7 +5,7 @@
     {
       "label": "Run RSpec current file with line",
       "type": "shell",
-      "command": "cd apps/backend && bundle exec rspec -fd -ff ${relative}:${input:LineNumber}",
+      "command": "docker compose -f docker-compose.yml exec -it app /bin/bash -c \"bundle exec rspec -fd -ff ${relative}:${input:LineNumber}\"",
       "group": "test",
       "problemMatcher":[
         {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -11,7 +11,7 @@
       "problemMatcher":[
         {
           "owner": "ruby",
-          "fileLocation": ["relative", "${workspaceFolder}"],
+          "fileLocation": [ "relative", "${workspaceFolder}" ],
           "pattern": {
             "regexp": "^rspec\\s+(.*):(\\d+)\\s+#\\s+(.*)$",
             "file": 1, "line": 2, "message": 3

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,8 +5,8 @@
     {
       "label": "Run RSpec current file with line",
       "type": "shell",
-      // "command": "echo ./$(echo ${relativeFile} | sed 's|apps/backend/||')",
-      "command": "docker compose -f docker-compose.yml exec -it app /bin/bash -c \"bundle exec rspec -fd -ff ./$(echo ${relativeFile} | sed 's|apps/backend/||')\"",
+      // localとコンテ内のディレクトリ構成が違うため、sedコマンドで不要なディレクトリを削除
+      "command": "docker compose -f docker-compose.yml exec -it app /bin/bash -c \"bundle exec rspec -fd -ff ./$(echo ${relativeFile} | sed 's|apps/backend/||'):${input:LineNumber}\"",
       "group": "test",
       "problemMatcher":[
         {


### PR DESCRIPTION
## 目的・背景
RSpecの実行で画面を行き来したり、コンテナに入ったりする時間がもったいないので、VSCodeで操作が完結するようにします。

## 受け入れ要件
- [x] なし
- [ ] あり
  - [ ] [URL](URL) を参照ください。

## 実装の概要
- `.vscode/tasks.json`を新たに作成してVSCodeのショートキーでテストを実行して検証できる仕組みを作ります。
- 実行ファイルの行番号も指定できるようにします。
- VSCodeの拡張機能のError Lensは入れておくほうがいいと思います。

## レビューで特に見て欲しいところ、不安に思っているところ

## 関連資料
- このPRに関連する資料のリンクをこちらに貼ってください。

## 参考文献
- 関連するドキュメントや外部リンクがあれば、こちらに追加してください。

---

## チェックリスト
- [x] 該当するラベルを設定
