### PR TITLE
simplecov導入

### DIFF
--- a/apps/backend/.gitignore
+++ b/apps/backend/.gitignore
@@ -43,6 +43,7 @@
 
 # Test
 /spec/examples.txt
+/coverage/*
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key

--- a/apps/backend/Gemfile
+++ b/apps/backend/Gemfile
@@ -56,4 +56,5 @@ group :test do
   gem 'rails-controller-testing' # コントローラーテストに`assigns`を戻す
   gem 'guard' # ファイルシステムの変更をハンドリング
   gem 'guard-rspec' # Guardを使用してテストを自動的かつインテリジェントに起動
+  gem 'simplecov', require: false # テストカバレッジを計測
 end

--- a/apps/backend/Gemfile.lock
+++ b/apps/backend/Gemfile.lock
@@ -84,6 +84,7 @@ GEM
     concurrent-ruby (1.1.10)
     crass (1.0.6)
     diff-lcs (1.5.0)
+    docile (1.4.0)
     dotenv (2.8.1)
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
@@ -273,6 +274,12 @@ GEM
       websocket (~> 1.0)
     semantic_range (3.0.0)
     shellany (0.0.1)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     sprockets (4.0.3)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -342,6 +349,7 @@ DEPENDENCIES
   rubocop-rails
   sass-rails (>= 6)
   selenium-webdriver
+  simplecov
   turbolinks (~> 5)
   tzinfo-data
   uglifier

--- a/apps/backend/spec/spec_helper.rb
+++ b/apps/backend/spec/spec_helper.rb
@@ -11,7 +11,14 @@
 # a separate helper file that requires the additional dependencies and performs
 # the additional setup, and require it from the spec files that actually need
 # it.
-#
+
+require 'simplecov'
+SimpleCov.start do
+  # simplecovから除外するファイルを指定
+  add_filter 'spec/'
+  add_filter 'config/'
+end
+
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate


### PR DESCRIPTION
## 目的・背景

コードカバレッジを計測できるようにsimplecovを追加します
ref: https://github.com/simplecov-ruby/simplecov

### 非機能要件
- `spec`配下と、`config`配下のファイルも対象に入っていたので、`add_filter`で除外した

https://github.com/aki366/caian-app/blob/99d9684a2fb9f1a80ef6848295d1e15e251c88b3/apps/backend/spec/spec_helper.rb#L18-L19

### カバレッジ確認方法
```
$ open coverage/index.html
```
コマンドを実行するだけで、ブラウザでカバレッジを確認することが出来たので、幸せになれそう。

![スクリーンショット 2024-03-03 22 04 04](https://github.com/aki366/caian-app/assets/96239914/bfd709ff-0b2a-4c11-9263-cafff5bb781c)

## 受け入れ要件
- [ ] なし
- [x] あり
  - [x] カバレッジ計測できること
  - [x] 計測対象外のファイルは除外されていること

## 実装の概要
何を実装したのか又はしたいのか、概要を記述してください。

## レビューで特に見て欲しいところ、不安に思っているところ
- レビューで特に見て欲しいところや、不安に思っているところがあれば記述してください。

## 関連資料
- このPRに関連する資料のリンクをこちらに貼ってください。

## 参考文献
- 関連するドキュメントや外部リンクがあれば、こちらに追加してください。

---

## チェックリスト
- [x] 該当するラベルを設定
