### PR TITLE
require 'logger' をen

### DIFF
--- a/apps/backend/config/environment.rb
+++ b/apps/backend/config/environment.rb
@@ -1,3 +1,7 @@
+# TODO: Rails7.1系になったら削除する
+# https://github.com/ruby-concurrency/concurrent-ruby/pull/1062
+require 'logger'
+
 # Load the Rails application.
 require_relative "application"
 


### PR DESCRIPTION
## 目的・背景
RSpecを実行した際に`logger` に関するエラーが発生していたので対処します。
ただし、Rails7.1系にアプデすると今回対処した内容は標準で対応されるので削除するようにTODOで7.1のキーワードを入れておきました。
ref: https://github.com/ruby-concurrency/concurrent-ruby/pull/1062

```
An error occurred while loading rails_helper.
Failure/Error: require_relative '../config/environment'

NameError:
  uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger
```

## 実装の概要

## レビューで特に見て欲しいところ、不安に思っているところ

## 関連資料

## 参考文献

---

## チェックリスト
- [ ] 該当するラベルを設定
