### PR TITLE
Feature/update bundle 20250315 fix logger error

### DIFF
--- a/apps/backend/Gemfile
+++ b/apps/backend/Gemfile
@@ -58,3 +58,7 @@ group :test do
   gem 'guard-rspec' # Guardを使用してテストを自動的かつインテリジェントに起動
   gem 'simplecov', require: false # テストカバレッジを計測
 end
+
+# Loggerのエラーを回避するための一時的なバージョン指定で、Rails7.1系のアプデ作業が終了したら削除する
+# ref: https://github.com/rails/rails/issues/54271
+gem 'concurrent-ruby', '<= 1.3.4'

--- a/apps/backend/Gemfile.lock
+++ b/apps/backend/Gemfile.lock
@@ -276,7 +276,11 @@ GEM
       rubocop-ast (>= 1.38.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
+<<<<<<< Updated upstream
     rubocop-ast (1.38.1)
+=======
+    rubocop-ast (1.39.0)
+>>>>>>> Stashed changes
       parser (>= 3.3.1.0)
     rubocop-rails (2.30.3)
       activesupport (>= 4.2.0)
@@ -363,6 +367,7 @@ DEPENDENCIES
   bootsnap
   bullet
   capybara
+  concurrent-ruby (<= 1.3.4)
   dotenv-rails
   factory_bot_rails
   faker


### PR DESCRIPTION
## 概要
`concurrent-ruby`のバージョンが1.3.5になるとRailsのバグでLoggerがエラーになるので、Railsのアプデを行うまでバージョンを固定します
ref: https://github.com/rails/rails/issues/54271

---

## チェックリスト
- [ ] 該当するラベルを設定
